### PR TITLE
Feature: Print `active_count` in tables with Zabbix

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,6 +120,8 @@ Get byte count for a specific EVC:
 22594175814
 ```
 
+Get tables statistics:
+
 ```
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01
 254 ## Number of tables in switch01
@@ -128,7 +130,7 @@ Get byte count for a specific EVC:
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000
 0 ## No table with this id
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::0 -s 5
-{'0': 28} ## active count in table 1
+{'0': 28} ## active count in table 0
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000 -s 5
 {} ## No table with this id
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01 -s 5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ export KYTOS_PASSWORD=changeme123
 
 #### How to use
 
-The `kytos_zabbix.py` script has a few monitoring capabilities, such as the monitoring option `-o`: 1 - status of switches; 2 - status of links; 3 - status of EVCs; 4 - statistics of EVCs. You can filter by the target to be monitored by using the option `-t` (target), example: to get the status of switch01 (dpid 00:00:00:00:00:00:00:01) one would use `-o 1 -t 00:00:00:00:00:00:00:01`. Furthermore, when collecting statistics for EVCs, you can filter by (option `-s`): 1 - bytes/UNI_A, 2 - bytes/UNI_Z , 3 - packets/UNI_A, 4 - packets/UNI_Z.
+The `kytos_zabbix.py` script has a few monitoring capabilities, such as the monitoring option `-o`: 1 - status of switches; 2 - status of links; 3 - status of EVCs; 4 - statistics of EVCs. You can filter by the target to be monitored by using the option `-t` (target), example: to get the status of switch01 (dpid 00:00:00:00:00:00:00:01) one would use `-o 1 -t 00:00:00:00:00:00:00:01`. To get status of table 1 of switch01 one would use `-o 6 -t 00:00:00:00:00:00:00:01::1`. Furthermore, when collecting statistics for EVCs, you can filter by (option `-s`): 1 - bytes/UNI_A, 2 - bytes/UNI_Z , 3 - packets/UNI_A, 4 - packets/UNI_Z.
 
 Here is the complete help and options:
 
@@ -52,7 +52,7 @@ optional arguments:
   -o {1,2,3,4,5,6}, --monitoring_option {1,2,3,4,5,6}
                         Monitoring option: 1 - for monitor nodes, 2 - for
                         monitor links, 3 - for monitor evcs (status), 4 - evc
-                        statistics, 5 - OpenFlow flows stats, 5 - OpenFlow tables stats
+                        statistics, 5 - OpenFlow flows stats, 6 - OpenFlow tables stats
   -t TARGET, --target TARGET
                         Item status (0-down/others, 1-disabled, 2-up/primary,
                         3-up/backup). Argument is the item id to be monitored
@@ -60,9 +60,10 @@ optional arguments:
   -z {1,2}, --zabbix_output {1,2}
                         Zabbix LLD: (1) Count number of lines in each output
                         or (2) list-only registers
-  -s {1,2,3,4}, --stats {1,2,3,4}
+  -s {1,2,3,4, 5}, --stats {1,2,3,4}
                         EVC statistics type: 1 - bytes/UNI_A, 2 - bytes/UNI_Z
                         , 3 - packets/UNI_A, 4 - packets/UNI_Z
+                        Table statistics type: 5 - active count, default - number of tables
 ```
 
 Examples:
@@ -117,6 +118,21 @@ Get byte count for a specific EVC:
 22594145833
 # /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 4 -t db608c96f05940 -s 2
 22594175814
+```
+
+```
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01
+254 ## Number of tables in switch01
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::0
+1 ## 1 table
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000
+0 ## No table with this id
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::0 -s 5
+{'0': 28} ## active count in table 1
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000 -s 5
+{} ## No table with this id
+# /usr/share/zabbix/externalscripts/kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01 -s 5
+{'0': 28, '1': 0, ..., '253': 0} ## in all tables
 ```
 
 Leveraging the above functions you can create a Zabbix template and dashboards to better monitor your Kytos-ng instance! At AmLight/FIU we have created our Kytos template for zabbix and some dashboards, please [`contact us`](https://www.amlight.net) if you are interested.

--- a/scripts/kytos_zabbix.py
+++ b/scripts/kytos_zabbix.py
@@ -157,7 +157,7 @@ def print_target_results(data, option, target):
         else:
             print("0")
 
-def print_flow_stats(data, target):    
+def print_flow_stats(data, target):
     if target:
         print(len(data.get(target, [])))
     else:

--- a/scripts/kytos_zabbix.py
+++ b/scripts/kytos_zabbix.py
@@ -44,7 +44,7 @@ parser.add_argument("-c", "--cache_policy", dest="cache_policy", default=60, hel
 parser.add_argument("-o", "--monitoring_option", dest="option", type=int, default=1, choices=[1, 2, 3, 4, 5, 6], help="Monitoring option: 1 - for monitor nodes, 2 - for monitor links, 3 - for monitor evcs (status), 4 - evc statistics, 5 - OpenFlow flows stats, 6 - OpenFlow tables stats")
 parser.add_argument("-t", "--target", dest="target", help="Item status (0-down/others, 1-disabled, 2-up/primary, 3-up/backup). Argument is the item id to be monitored (depending on the -o option).")
 parser.add_argument("-z", "--zabbix_output", dest="count_output", type=int, choices=[1, 2], help="Zabbix LLD: (1) Count number of lines in each output or (2) list-only registers", default=None)
-parser.add_argument("-s", "--stats", dest="stats", type=int, default=1, choices=[1, 2, 3, 4], help="EVC statistics type: 1 - bytes/UNI_A, 2 - bytes/UNI_Z , 3 - packets/UNI_A, 4 - packets/UNI_Z")
+parser.add_argument("-s", "--stats", dest="stats", type=int, default=1, choices=[1, 2, 3, 4, 5], help="EVC statistics type: 1 - bytes/UNI_A, 2 - bytes/UNI_Z , 3 - packets/UNI_A, 4 - packets/UNI_Z. Table statistics type: 5 - active count, default - number of tables")
 
 args = parser.parse_args()
 
@@ -59,7 +59,7 @@ if args.authfile:
     args.password = authdata[1].strip()
 
 args.url = os.environ.get("KYTOS_URL", args.url)
-args.timeout = os.environ.get("KYTOS_TIMEOUT", args.timeout)
+args.timeout = int(os.environ.get("KYTOS_TIMEOUT", args.timeout))
 args.username = os.environ.get("KYTOS_USERNAME", args.username)
 args.password = os.environ.get("KYTOS_PASSWORD", args.password)
 
@@ -157,9 +157,31 @@ def print_target_results(data, option, target):
         else:
             print("0")
 
-def print_kytos_stats(data, target):
+def print_flow_stats(data, target):    
     if target:
         print(len(data.get(target, [])))
+    else:
+        l = 0
+        for s in data:
+            l+= len(data[s])
+        print(l)
+
+def print_tables_stats(data, target, stats_type):
+    if target:
+        split = target.split('::')
+        dpid = split[0]
+        tables = data.get(dpid, [])
+        if len(split) > 1:
+            table_id = split[1]
+            if table_id in tables:
+                tables = {table_id: tables.get(table_id)} 
+            else:
+                tables = {} 
+        if stats_type != 5:
+            print(len(tables))
+        else:             
+            stats = {table_id:table.get('active_count') for table_id, table in tables.items()}
+            print(stats)  
     else:
         l = 0
         for s in data:
@@ -218,8 +240,10 @@ data = get_kytos_data(args.url, args.option)
 
 if args.option == 4:
     print_stats(data, args.target, args.stats)
-elif args.option in [5, 6]:
-    print_kytos_stats(data, args.target)
+elif args.option == 5:
+    print_flow_stats(data, args.target)
+elif args.option == 6:
+    print_tables_stats(data, args.target, args.stats)
 elif args.target:
     print_target_results(data, args.option, args.target)
 elif args.count_output == 1:


### PR DESCRIPTION
Closes #3 

### Summary

Add option 5 in stats (-s 5) in Zabbix to print the `active_count` field of tables. If this option is not specified, the number of tables is printed.
`::` is allowed in target to specify table_id.
Other table fields can now be easily added to print similar to `active_count` with -s > 5.

### Local Tests

```
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01
254 ## Number of tables in switch01
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::0
1 ## 1 table
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000
0 ## No table with this id
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::0 -s 5
{'0': 28} ## active count in table 0
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01::2000 -s 5
{} ## No table with this id
# ./kytos_zabbix.py -o 6 -t 00:00:00:00:00:00:00:01 -s 5
{'0': 28, '1': 0, ..., '253': 0} ## in all tables
```
### End-to-End Tests
N/A