### PR TITLE
Updated `kytos_zabbix.py`

### DIFF
--- a/scripts/kytos_zabbix.py
+++ b/scripts/kytos_zabbix.py
@@ -133,6 +133,11 @@ def convert_status(active, enabled):
     else:
         return "0"
 
+def compare_paths(path1, path2):
+    if len(path1) != len(path2):
+        return False
+    return all(x.get('id') == y.get('id') for x,y in zip(path1, path2))
+
 def print_target_results(data, option, target):
     if target not in data:
         print("Unknown target=%s" % (target))
@@ -150,9 +155,9 @@ def print_target_results(data, option, target):
         if status != "2" or evc.get("dynamic_backup_path", False):
             print(status)
             return
-        if evc["current_path"] == evc["primary_path"]:
+        if compare_paths(evc["current_path"], evc["primary_path"]):
             print("2")
-        elif evc["current_path"] == evc["backup_path"]:
+        elif compare_paths(evc["current_path"], evc["backup_path"]):
             print("3")
         else:
             print("0")


### PR DESCRIPTION
Closes #20

### Summary

Path comparison is done by checking link IDs instead of comparing every key and item.
Copied from Italos [comment](https://github.com/kytos-ng/mef_eline/issues/592#issuecomment-2546340932) since it suited use cases.

### Local Tests
Tried new method in Kytos console with different dictionaries of the same path.

### End-to-End Tests
N/A