### PR TITLE
adding feature of port status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the kytos_stats NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Event listner for ``kytos/of_core.port_stats`.
+- Add GET ``v1/port/stats`` endpoint to listing port stats by dpid and port.
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Subscribed
 
 - ``kytos/of_core.flow_stats.received``
 - ``kytos/of_core.table_stats.received``
+- ``kytos/of_core.port_stats``
 
 
 .. TAGs

--- a/main.py
+++ b/main.py
@@ -8,7 +8,8 @@ This NApp does operations with flows not covered by Kytos itself.
 from collections import defaultdict
 
 from kytos.core import KytosNApp, log, rest
-from kytos.core.helpers import listen_to
+from kytos.core.events import KytosEvent
+from kytos.core.helpers import listen_to, alisten_to
 from kytos.core.rest_api import HTTPException, JSONResponse, Request
 
 
@@ -258,12 +259,8 @@ class Main(KytosNApp):
                 self.tables_stats_dict[switch_id] = {}
             self.tables_stats_dict[switch_id][table.table_id] = table
 
-    @listen_to('kytos/of_core.port_stats')
-    def on_port_stats(self, event):
-        """Capture port stats messages for OpenFlow 1.3."""
-        self.handle_port_stats(event)
-
-    def handle_port_stats(self, event):
+    @alisten_to('kytos/of_core.port_stats')
+    async def on_port_stats(self, event: KytosEvent) -> None:
         """Handle port stats messages for OpenFlow 1.3."""
         port_stats = event.content.get('port_stats')
         switch = event.content.get('switch')

--- a/main.py
+++ b/main.py
@@ -131,7 +131,11 @@ class Main(KytosNApp):
     async def port_stats(self, request: Request) -> JSONResponse:
         """Return the port stats by dpid, and optionally by port."""
         dpids = request.query_params.getlist("dpid")
-        ports = list(map(int, request.query_params.getlist("port")))
+        try:
+            ports = list(map(int, request.query_params.getlist("port")))
+        except (ValueError, TypeError):
+            detail = "'port' value is supposed to be an integer"
+            raise HTTPException(400, detail=detail)
         return JSONResponse(self.port_stats_filter(dpids, ports))
 
     @rest('v1/packet_count/{flow_id}')

--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ class Main(KytosNApp):
         return JSONResponse(table_stats_dpid)
 
     @rest('v1/port/stats')
-    def port_stats(self, request: Request) -> JSONResponse:
+    async def port_stats(self, request: Request) -> JSONResponse:
         """Return the port stats by dpid, and optionally by port."""
         dpids = request.query_params.getlist("dpid")
         ports = list(map(int, request.query_params.getlist("port")))

--- a/main.py
+++ b/main.py
@@ -91,7 +91,6 @@ class Main(KytosNApp):
             for port_no in port_keys:
                 if p_stat := self.port_stats_dict[dpid].get(port_no):
                     port_stats[dpid][port_no] = p_stat
-        print(port_stats)
         return port_stats
 
     @rest('v1/flow/stats')

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ class Main(KytosNApp):
                     table_stats_by_id[dpid][table_id] = table_dict
         return table_stats_by_id
 
-    def port_stats_filter(self, f_dpids, f_ports):
+    def port_stats_filter(self, f_dpids: list[str], f_ports: list[int]) -> dict:
         """ Auxiliar funcion for v1/port/stats endpoint implementation.
         """
         port_stats = {}

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 from kytos.core import KytosNApp, log, rest
 from kytos.core.events import KytosEvent
-from kytos.core.helpers import listen_to, alisten_to
+from kytos.core.helpers import alisten_to, listen_to
 from kytos.core.rest_api import HTTPException, JSONResponse, Request
 
 
@@ -82,7 +82,9 @@ class Main(KytosNApp):
                     table_stats_by_id[dpid][table_id] = table_dict
         return table_stats_by_id
 
-    def port_stats_filter(self, f_dpids: list[str], f_ports: list[int]) -> dict:
+    def port_stats_filter(
+        self, f_dpids: list[str], f_ports: list[int]
+    ) -> dict:
         """ Auxiliar funcion for v1/port/stats endpoint implementation.
         """
         port_stats = {}

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ class Main(KytosNApp):
         log.info('Starting Kytos/Amlight flow manager')
         self.flows_stats_dict = {}
         self.tables_stats_dict = {}
+        self.port_stats_dict = {}
 
     def execute(self):
         """This method is executed right after the setup method execution.
@@ -77,6 +78,22 @@ class Main(KytosNApp):
                     table_stats_by_id[dpid][table_id] = table_dict
         return table_stats_by_id
 
+    def port_stats_filter(self, f_dpids, f_ports):
+        """ Auxiliar funcion for v1/port/stats endpoint implementation.
+        """
+        port_stats = {}
+        dpid_keys = f_dpids if f_dpids else self.port_stats_dict.keys()
+        for dpid in dpid_keys:
+            port_stats[dpid] = {}
+            port_keys = f_ports
+            if not f_ports:
+                port_keys = self.port_stats_dict.get(dpid, {}).keys()
+            for port_no in port_keys:
+                if p_stat := self.port_stats_dict[dpid].get(port_no):
+                    port_stats[dpid][port_no] = p_stat
+        print(port_stats)
+        return port_stats
+
     @rest('v1/flow/stats')
     def flow_stats(self, request: Request) -> JSONResponse:
         """Return the flows stats by dpid.
@@ -100,6 +117,13 @@ class Main(KytosNApp):
         table_ids = list(map(int, table_ids))
         table_stats_dpid = self.table_stats_by_dpid_table_id(dpids, table_ids)
         return JSONResponse(table_stats_dpid)
+
+    @rest('v1/port/stats')
+    def port_stats(self, request: Request) -> JSONResponse:
+        """Return the port stats by dpid, and optionally by port."""
+        dpids = request.query_params.getlist("dpid")
+        ports = list(map(int, request.query_params.getlist("port")))
+        return JSONResponse(self.port_stats_filter(dpids, ports))
 
     @rest('v1/packet_count/{flow_id}')
     def packet_count(self, request: Request) -> JSONResponse:
@@ -227,3 +251,34 @@ class Main(KytosNApp):
             if switch_id not in self.tables_stats_dict:
                 self.tables_stats_dict[switch_id] = {}
             self.tables_stats_dict[switch_id][table.table_id] = table
+
+    @listen_to('kytos/of_core.port_stats')
+    def on_port_stats(self, event):
+        """Capture port stats messages for OpenFlow 1.3."""
+        self.handle_port_stats(event)
+
+    def handle_port_stats(self, event):
+        """Handle port stats messages for OpenFlow 1.3."""
+        port_stats = event.content.get('port_stats')
+        switch = event.content.get('switch')
+        if not port_stats or not switch:
+            return
+        for port in port_stats:
+            self.port_stats_dict.setdefault(switch.id, {})
+            self.port_stats_dict[switch.id][port.port_no.value] = {
+                "port_no": port.port_no.value,
+                "rx_packets": port.rx_packets.value,
+                "tx_packets": port.tx_packets.value,
+                "rx_bytes": port.rx_bytes.value,
+                "tx_bytes": port.tx_bytes.value,
+                "rx_dropped": port.rx_dropped.value,
+                "tx_dropped": port.tx_dropped.value,
+                "rx_errors": port.rx_errors.value,
+                "tx_errors": port.tx_errors.value,
+                "rx_frame_err": port.rx_frame_err.value,
+                "rx_over_err": port.rx_over_err.value,
+                "rx_crc_err": port.rx_crc_err.value,
+                "collisions": port.collisions.value,
+                "duration_sec": port.duration_sec.value,
+                "duration_nsec": port.duration_nsec.value,
+            }

--- a/openapi.yml
+++ b/openapi.yml
@@ -118,6 +118,105 @@ paths:
                             type: integer
                             format: int64
                             example: 0
+  /api/amlight/kytos_stats/v1/port/stats:
+    get:
+      tags:
+        - object
+      summary: Return port stats.
+      description: Return the stats of ports given a list of dpids and optionally port numbers.
+      parameters:
+        - name: dpid
+          schema:
+            type: array
+            items:
+              type: string
+          description: List of switch ids
+          required: false
+          in: query
+          example: ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]
+        - name: port
+          schema:
+            type: array
+            items:
+              type: string
+          description: List of port numbers
+          required: false
+          in: query
+          example: ["1", "2"]
+      responses:
+        200:
+          description: Describe a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  switch:
+                    type: object
+                    properties:
+                      port_stats:
+                        type: object
+                        properties:
+                          port_no:
+                            type: integer
+                            format: int32
+                            example: 0
+			  rx_packets:
+                            type: integer
+                            format: int64
+                            example: 0
+			  tx_packets:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_bytes:
+                            type: integer
+                            format: int64
+                            example: 0
+			  tx_bytes:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_dropped:
+                            type: integer
+                            format: int64
+                            example: 0
+			  tx_dropped:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_errors:
+                            type: integer
+                            format: int64
+                            example: 0
+			  tx_errors:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_frame_err:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_over_err:
+                            type: integer
+                            format: int64
+                            example: 0
+			  rx_crc_err:
+                            type: integer
+                            format: int64
+                            example: 0
+			  collisions:
+                            type: integer
+                            format: int64
+                            example: 0
+			  duration_sec:
+                            type: integer
+                            format: int64
+                            example: 0
+			  duration_nsec:
+                            type: integer
+                            format: int64
+                            example: 0
   /api/amlight/kytos_stats/v1/packet_count/{flow_id}:
     get:
       summary: Packet count of an specific flow.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -368,6 +368,14 @@ class TestMain:
         assert len(data["0x1"]) == 1
         assert "1" in data["0x1"]
 
+        endpoint = "/port/stats?dpid=0x1&port=a"
+        url = f"{self.base_endpoint}{endpoint}"
+        response = await self.api_client.get(url)
+        assert response.status_code == 400
+        data = response.json()
+        desc = data["description"]
+        assert "'port' value is supposed to be an integer" in desc
+
     async def test_on_port_stats(self):
         """Test handle_stats_received function."""
         expected_dict = {

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -368,7 +368,7 @@ class TestMain:
         assert len(data["0x1"]) == 1
         assert "1" in data["0x1"]
 
-    def test_handle_port_stats(self):
+    async def test_on_port_stats(self):
         """Test handle_stats_received function."""
         expected_dict = {
             "00:00:00:00:00:00:00:01": {
@@ -395,7 +395,7 @@ class TestMain:
         name = "kytos/of_core.port_stats"
         event = get_kytos_event_mock(name=name, content={})
 
-        self.napp.handle_port_stats(event)
+        await self.napp.on_port_stats(event)
 
         assert not self.napp.port_stats_dict
 
@@ -406,7 +406,7 @@ class TestMain:
 
         event = get_kytos_event_mock(name=name, content=content)
 
-        self.napp.handle_port_stats(event)
+        await self.napp.on_port_stats(event)
 
         assert self.napp.port_stats_dict == expected_dict
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -24,7 +24,8 @@ class TestMain:
         """Verify all event listeners registered."""
         expected_events = [
             'kytos/of_core.flow_stats.received',
-            'kytos/of_core.table_stats.received'
+            'kytos/of_core.table_stats.received',
+            'kytos/of_core.port_stats',
         ]
         actual_events = self.napp.listeners()
 
@@ -328,6 +329,87 @@ class TestMain:
         expected = table_by_sw
         assert response.json() == expected
 
+    async def test_port_stats_filter(self):
+        """Test table_stats rest call."""
+        self.napp.port_stats_dict = {
+            "0x1": {
+                1: {
+                    "port_no": 1,
+                },
+                2: {
+                    "port_no": 2,
+                },
+            },
+            "0x2": {
+                99: {
+                    "port_no": 99,
+                },
+            },
+        }
+        expected_result = {}
+        for dpid, sw in self.napp.port_stats_dict.items():
+            expected_result[dpid] = {}
+            for port_no, port in sw.items():
+                expected_result[dpid][str(port_no)] = port
+
+        endpoint = "/port/stats"
+        url = f"{self.base_endpoint}{endpoint}"
+        response = await self.api_client.get(url)
+        assert response.status_code == 200
+        assert response.json() == expected_result
+
+        endpoint = "/port/stats?dpid=0x1&port=1"
+        url = f"{self.base_endpoint}{endpoint}"
+        response = await self.api_client.get(url)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert "0x1" in data
+        assert len(data["0x1"]) == 1
+        assert "1" in data["0x1"]
+
+    def test_handle_port_stats(self):
+        """Test handle_stats_received function."""
+        expected_dict = {
+            "00:00:00:00:00:00:00:01": {
+                1: {
+                    "port_no": 1,
+                    "rx_packets": 0,
+                    "tx_packets": 0,
+                    "rx_bytes": 0,
+                    "tx_bytes": 0,
+                    "rx_dropped": 0,
+                    "tx_dropped": 0,
+                    "rx_errors": 0,
+                    "tx_errors": 0,
+                    "rx_frame_err": 0,
+                    "rx_over_err": 0,
+                    "rx_crc_err": 0,
+                    "collisions": 0,
+                    "duration_sec": 0,
+                    "duration_nsec": 0,
+                },
+            },
+        }
+
+        name = "kytos/of_core.port_stats"
+        event = get_kytos_event_mock(name=name, content={})
+
+        self.napp.handle_port_stats(event)
+
+        assert not self.napp.port_stats_dict
+
+        switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        switch.id = switch.dpid
+        port_stats = self._get_mocked_port_stat(port_no=1)
+        content = {"switch": switch, "port_stats": [port_stats]}
+
+        event = get_kytos_event_mock(name=name, content=content)
+
+        self.napp.handle_port_stats(event)
+
+        assert self.napp.port_stats_dict == expected_dict
+
     @patch("napps.amlight.kytos_stats.main.Main.table_stats_by_dpid_table_id")
     async def test_table_stats_by_dpid_table_id_without_dpid(self,
                                                              mock_from_table):
@@ -402,6 +484,26 @@ class TestMain:
 
         replies_tables = [table]
         return replies_tables
+
+    def _get_mocked_port_stat(self, **kwargs):
+        """Helper method to create mock port stats."""
+        port_stats = MagicMock()
+        port_stats.port_no.value = kwargs.get("port_no", 0)
+        port_stats.rx_packets.value = kwargs.get("rx_packets", 0)
+        port_stats.tx_packets.value = kwargs.get("tx_packets", 0)
+        port_stats.rx_bytes.value = kwargs.get("rx_bytes", 0)
+        port_stats.tx_bytes.value = kwargs.get("tx_bytes", 0)
+        port_stats.rx_dropped.value = kwargs.get("rx_dropped", 0)
+        port_stats.tx_dropped.value = kwargs.get("tx_dropped", 0)
+        port_stats.rx_errors.value = kwargs.get("rx_errors", 0)
+        port_stats.tx_errors.value = kwargs.get("tx_errors", 0)
+        port_stats.rx_frame_err.value = kwargs.get("rx_frame_err", 0)
+        port_stats.rx_over_err.value = kwargs.get("rx_over_err", 0)
+        port_stats.rx_crc_err.value = kwargs.get("rx_crc_err", 0)
+        port_stats.collisions.value = kwargs.get("collisions", 0)
+        port_stats.duration_sec.value = kwargs.get("duration_sec", 0)
+        port_stats.duration_nsec.value = kwargs.get("duration_nsec", 0)
+        return port_stats
 
     def _get_mocked_flow_base(self):
         """Helper method to create a mock flow object."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -376,8 +376,11 @@ class TestMain:
         desc = data["description"]
         assert "'port' value is supposed to be an integer" in desc
 
-    async def test_on_port_stats(self):
+    async def test_on_port_stats(self, monkeypatch):
         """Test handle_stats_received function."""
+        mock = MagicMock()
+        mock.utcnow.return_value = "some_time"
+        monkeypatch.setattr("napps.amlight.kytos_stats.main.datetime", mock)
         expected_dict = {
             "00:00:00:00:00:00:00:01": {
                 1: {
@@ -396,6 +399,7 @@ class TestMain:
                     "collisions": 0,
                     "duration_sec": 0,
                     "duration_nsec": 0,
+                    "updated_at": "some_time"
                 },
             },
         }


### PR DESCRIPTION
Closes #24

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

Unit tests were added to cover the new functions. Additionally, here is an example of using the new endpoint:

```
# curl -s "http://127.0.0.1:8181/api/amlight/kytos_stats/v1/port/stats?dpid=00:aa:bb:cc:dd:ee:ff:01&port=133" | jq -r
{
  "00:aa:bb:cc:dd:ee:ff:01": {
    "133": {
      "port_no": 133,
      "rx_packets": 8,
      "tx_packets": 0,
      "rx_bytes": 612,
      "tx_bytes": 0,
      "rx_dropped": 0,
      "tx_dropped": 0,
      "rx_errors": 0,
      "tx_errors": 0,
      "rx_frame_err": 0,
      "rx_over_err": 0,
      "rx_crc_err": 0,
      "collisions": 0,
      "duration_sec": 24056,
      "duration_nsec": 551442861
    }
  }
}
```

### End-to-End Tests

N/A